### PR TITLE
未選擇字符時字寬被強制換成1000

### DIFF
--- a/Nine Box View.glyphsPlugin/Contents/Resources/plugin.py
+++ b/Nine Box View.glyphsPlugin/Contents/Resources/plugin.py
@@ -64,13 +64,10 @@ class NineBoxPreviewView(NSView):
             MARGIN = min(rect.size.width, rect.size.height) * MARGIN_RATIO
 
             # === 計算網格尺寸 / Calculate the grid size ===
-            # 計算基礎寬度 - 使用目前字型的平均寬度或預設值 / Calculate the base width - use the average width of the current font or the default value
-            baseWidth = 1000  # 預設基礎寬度 / Default base width
+            # 使用 getBaseWidth 方法取得基準寬度
+            baseWidth = self.wrapper.plugin.getBaseWidth()
 
-            # 如果有選取的字符層，使用其寬度 / If there is a selected character layer, use its width
-            if Glyphs.font.selectedLayers:
-                baseWidth = Glyphs.font.selectedLayers[0].width
-
+            # 計算最大寬度
             maxWidth = baseWidth
             if display_chars:
                 for char in display_chars:
@@ -501,6 +498,32 @@ class NineBoxView(GeneralPlugin):
 
 
     # === 工具方法 / Utility Methods ===
+
+    @objc.python_method
+    def getBaseWidth(self):
+        """取得基準寬度 / Get the base width"""
+        if not Glyphs.font:
+            return 1000
+
+        currentMaster = Glyphs.font.selectedFontMaster
+
+        # 1. 檢查主板是否有 Default Layer Width 參數 / Check if the master has the Default Layer Width parameter
+        defaultWidth = None
+        if currentMaster.customParameters['Default Layer Width']:
+            defaultWidth = float(currentMaster.customParameters['Default Layer Width'])
+            if defaultWidth > 0:
+                return defaultWidth
+
+        # 2. 使用選取的字符層寬度 / Use the width of the selected character layer
+        if Glyphs.font.selectedLayers:
+            return Glyphs.font.selectedLayers[0].width
+
+        # 4. 使用 em square 寬度
+        if hasattr(currentMaster, 'width'):
+            return max(currentMaster.width, 500)
+
+        # 5. 最後的預設值
+        return 1000
 
     @objc.python_method
     def parseInputText(self, text):


### PR DESCRIPTION
Fixes #17

## Sourcery总结

通过添加一种方法来动态确定基于字体设置和选定图层的宽度，修复了在未选择字符时强制宽度的问题。

错误修复：
- 通过实现一种动态确定基础宽度的方法，修复了在未选择字符时基础宽度始终设置为1000的问题。

增强功能：
- 引入新方法 'getBaseWidth'，根据各种条件计算基础宽度，包括检查 'Default Layer Width' 参数、使用选定字符图层的宽度，以及默认为em方框宽度或备用值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the base width calculation by adding a method to dynamically determine the width based on font settings and selected layers, addressing the issue of forced width when no character is selected.

Bug Fixes:
- Fix the issue where the base width was always set to 1000 when no character was selected by implementing a method to determine the base width dynamically.

Enhancements:
- Introduce a new method 'getBaseWidth' to calculate the base width based on various conditions, including checking for a 'Default Layer Width' parameter, using the width of the selected character layer, and defaulting to the em square width or a fallback value.

</details>